### PR TITLE
Item swapping bug fix

### DIFF
--- a/src/main/kotlin/dev/emortal/marathon/game/MarathonGame.kt
+++ b/src/main/kotlin/dev/emortal/marathon/game/MarathonGame.kt
@@ -24,6 +24,7 @@ import net.minestom.server.event.inventory.InventoryPreClickEvent
 import net.minestom.server.event.item.ItemDropEvent
 import net.minestom.server.event.player.PlayerChangeHeldSlotEvent
 import net.minestom.server.event.player.PlayerMoveEvent
+import net.minestom.server.event.player.PlayerSwapItemEvent
 import net.minestom.server.event.player.PlayerUseItemEvent
 import net.minestom.server.instance.Instance
 import net.minestom.server.instance.block.Block
@@ -181,6 +182,9 @@ class MarathonGame(gameOptions: GameOptions) : Game(gameOptions) {
             isCancelled = true
         }
         listenOnly<InventoryPreClickEvent> {
+            isCancelled = true
+        }
+        listenOnly<PlayerSwapItemEvent> {
             isCancelled = true
         }
 


### PR DESCRIPTION
I don't know if this is a bug, but if you press `f` on an item of the block palette, it swaps to the offhand. 
If it is a bug, this should fix it.